### PR TITLE
Snowflake.Data library version upgrade  1.1.3  -> 1.2.9 

### DIFF
--- a/Frends.Community.SnowflakeData/Frends.Community.SnowflakeData.csproj
+++ b/Frends.Community.SnowflakeData/Frends.Community.SnowflakeData.csproj
@@ -9,7 +9,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.0.11</Version>
+    <Version>0.1.01</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>0.0.2.0</AssemblyVersion>
     <FileVersion>0.0.2.0</FileVersion>
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Snowflake.Data" Version="1.1.3" />
+    <PackageReference Include="Snowflake.Data" Version="1.2.9" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Frends.Community.SnowflakeData
 
-frends Community Task for Echo
+frends Community Task for Retriving data from [Snowflake](https://www.snowflake.com/)
 
 [![Actions Status](https://github.com/CommunityHiQ/Frends.Community.SnowflakeData/workflows/PackAndPushAfterMerge/badge.svg)](https://github.com/CommunityHiQ/Frends.Community.SnowflakeData/actions) ![MyGet](https://img.shields.io/myget/frends-community/v/Frends.Community.SnowflakeData) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) 
 


### PR DESCRIPTION
Apparently there was a bug in release 1.1.3 of Snowflake.Data library, that caused the frends agent to crash when any exception occurred in Snowflake. 
I upgraded the Snowflake.Data library to 1.2.9 
Also bumbed the verision number to 0.1.01 , so that the new version of the library can be taken into production with a 0.0.x version number where this bug has occurred... and then when/if this is pull request is accepted  version can be updated to "official".